### PR TITLE
Incorporating older help content changes

### DIFF
--- a/app/views/help/bookmarking.md
+++ b/app/views/help/bookmarking.md
@@ -1,0 +1,20 @@
+<% title "How can I bookmark Communicart so it’s easier to find my way back to?" %>
+
+## Creating a bookmark right now
+
+The easiest way to create a bookmark right now is this:
+1. Find the space just below the address bar in your browser. It will either be empty or have other bookmarks.
+1. Click and drag the word Communicart below to that space.
+
+**[Communicart](https://cap.18f.gov/)**
+
+_Communicart_ should now appear at the top of your browser. Clicking it will take you to the application homepage.
+
+## Bookmarking in different browsers
+
+For more details or to troubleshoot problems with bookmarking the page, different browsers work just a little bit differently. For help, choose your browser from the list below.
+
+- [Chrome](https://support.google.com/chrome/answer/95739?hl=en)
+- [Internet Explorer](http://windows.microsoft.com/en-us/internet-explorer/add-view-organize-favorites) (By default, this is instructions for the most recent version. Click the version name in the upper right to choose an older version.)
+- [Firefox](https://support.mozilla.org/en-US/kb/create-bookmarks-save-your-favorite-webpages)
+- [Safari](https://support.apple.com/kb/PH19265?locale=en_US)

--- a/app/views/help/editing_user_profile.md
+++ b/app/views/help/editing_user_profile.md
@@ -1,0 +1,8 @@
+<% title "Can I add my name to my profile or change the name that shows up?" %>
+
+Yes. If your name does not show up after you log in, we encourage you to add it. It may be easier for other people involved in your requests to recognize you by the name you use regularly than by your email address. To add yours:
+
+1. Navigate to [your profile page](/profile). (You can also get there by clicking your email address in the upper right of any Communicart page.)
+2. Add your first and last name and click _Update profile_.
+
+If you need to edit your name — perhaps you use a different name than the one that shows up, or there is a typo — you can go back to your profile page and edit it at any time.

--- a/app/views/help/modifying_requests_already_approved.md
+++ b/app/views/help/modifying_requests_already_approved.md
@@ -1,0 +1,22 @@
+<% title "What if I modify a request that has already been approved?" %>
+
+You can [modify a request](./modifying_requests) that has already been approved just like you do with pending requests. In some cases, however, you will need re-approval on that request.
+
+### Modified by budget approvers
+
+If you are a budget approver, Communicart will notify users of changes you make to approved requests. However, we still treat the approval process as complete.
+
+### Changes by other users that require re-approval
+
+If you are the submitters or first tier approver, you will need budget re-approval for any of these changes:
+
+- Increasing the purchase amount
+- Changing the org code, function code, or SOC code
+- Changing the building number
+- Changing the RWA number
+
+When you submit one of these modifications, approvers will get two emails. The first will tell them the approved request was modified. The second will request approval of the new version of the request.
+
+### Decreasing the purchase amount
+
+Decreasing the purchase amount does not require re-approval. It does require notification to the budget approver that you made a change. When you modify, Communicart will send an email to let them know.

--- a/app/views/help/removing_self_observer.md
+++ b/app/views/help/removing_self_observer.md
@@ -1,0 +1,9 @@
+<% title "How can I remove myself from being an observer on a request?"%>
+
+If you were added as an observer and no longer want to receive updates as a purchase request progresses:
+
+1. Go to the detail page for the request.
+1. On the details page, scroll down to the Observers section.
+1. Next to your own name, click _Remove_.
+
+You should see a message verifying that you have been removed as an observer. You will no longer receive updates about the purchase request. Note that you cannot remove users other than yourself from being observers.


### PR DESCRIPTION
- instructions for bookmarking
- adding your name (editing profile, so it can be expanded if/when more
  profile info goes in)
- modifying approved requests
- removing yourself as an observer
